### PR TITLE
Atualiza payload de criação de sessão WAHA

### DIFF
--- a/gerenciador_sistema.py
+++ b/gerenciador_sistema.py
@@ -224,10 +224,28 @@ class GerenciadorWAHA:
                 "name": "default",
                 "start": True,
                 "config": {
+                    "metadata": {
+                        "user.id": "123",
+                        "user.email": "bot@exemplo.com"
+                    },
+                    "proxy": None,
+                    "debug": False,
+                    "noweb": {
+                        "store": {
+                            "enabled": True,
+                            "fullSync": False
+                        }
+                    },
                     "webhooks": [
                         {
                             "url": webhook_url,
-                            "events": ["message", "session.status"]
+                            "events": [
+                                "message",
+                                "session.status"
+                            ],
+                            "hmac": None,
+                            "retries": None,
+                            "customHeaders": None
                         }
                     ]
                 }


### PR DESCRIPTION
## Summary
- Ajusta `GerenciadorWAHA.criar_sessao` para enviar payload completo com metadata, proxy, debug, noweb.store e campos de webhook adicionais

## Testing
- `python - <<'PY'
from gerenciador_sistema import GerenciadorWAHA
waha = GerenciadorWAHA()
print('Starting container...')
started = waha.iniciar_container()
print('Container started:', started)
print('Creating session...')
result = waha.criar_sessao('http://localhost:8000/webhook')
print('Session creation result:', result)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689509c9d7bc832c84d0dcb16aac30a6