### PR TITLE
Load environment variables before importing WAHA client

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,8 @@ from fastapi import FastAPI, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 
+load_dotenv()  # Carrega variáveis de ambiente antes de importações locais
+
 from helpers_compartilhados.helpers import configurar_logging
 # CORREÇÃO: Importação atualizada para langchain-ollama
 from langchain_ollama import OllamaLLM
@@ -17,7 +19,6 @@ from app.core.cliente_waha import cliente_waha
 from app.core.gerenciador_contexto import gerenciador_contexto
 
 # --- Configuração Inicial ---
-load_dotenv()
 configurar_logging('log_bot')
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Load dotenv before importing modules that require environment configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895111303ec832ca0a7a8303d2f5cd3