### PR TITLE
Add WAHA API key checks to configuration test

### DIFF
--- a/gerenciador_sistema.py
+++ b/gerenciador_sistema.py
@@ -686,15 +686,17 @@ class TestadorSistema:
         load_dotenv()
         
         vars_obrigatorias = [
-            'OLLAMA_BASE_URL', 'LLM_MODEL', 'WAHA_BASE_URL'
+            'OLLAMA_BASE_URL', 'LLM_MODEL', 'WAHA_BASE_URL',
+            'WAHA_API_KEY_PLAIN', 'WAHA_API_KEY'
         ]
-        
+
         faltando = [var for var in vars_obrigatorias if not os.getenv(var)]
-        
+
         if faltando:
-            print_aviso(f"Variáveis faltando: {', '.join(faltando)}")
+            for var in faltando:
+                print_aviso(f"Variável de ambiente obrigatória faltando: {var}")
             return False
-        
+
         return True
     
     async def _testar_ollama(self) -> bool:


### PR DESCRIPTION
## Summary
- require WAHA API key variables during environment configuration checks
- emit explicit warning for each missing environment variable

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895ffe52b4c832ca956e1fee9ecdf56