### PR TITLE
Automate WAHA API key handling

### DIFF
--- a/configurar_webhook_waha.py
+++ b/configurar_webhook_waha.py
@@ -437,18 +437,21 @@ class ConfiguradorWebhookWAHA:
         
         # Verificar se já existe uma API key válida
         existing_hash = os.getenv("WAHA_API_KEY")
-        if existing_hash and existing_hash.startswith("sha512:") and len(existing_hash) > 20:
+        existing_plain = os.getenv("WAHA_API_KEY_PLAIN")
+
+        if existing_hash and existing_plain:
             print_info("API key existente encontrada no .env")
             self.waha_api_key_hash = existing_hash
-            self.waha_api_key_plain = input(
-                "Digite a API key em texto plano correspondente: "
-            ).strip()
+            self.waha_api_key_plain = existing_plain
         else:
             print_info("Gerando nova API key segura...")
             plain, hashed = self.gerar_api_key_segura()
             self.waha_api_key_plain = plain
             self.waha_api_key_hash = hashed
             self.atualizar_env("WAHA_API_KEY", hashed)
+            self.atualizar_env("WAHA_API_KEY_PLAIN", plain)
+            os.environ["WAHA_API_KEY"] = hashed
+            os.environ["WAHA_API_KEY_PLAIN"] = plain
             print_sucesso("Nova API key gerada e salva no .env")
             print_aviso(f"Guarde a chave em local seguro: {plain}")
         

--- a/gerenciador_sistema.py
+++ b/gerenciador_sistema.py
@@ -99,23 +99,19 @@ class GerenciadorWAHA:
         # API key em hash (obrigatória) e chave em texto plano
         self.api_key_hash = os.getenv("WAHA_API_KEY")
         self.api_key_plain = os.getenv("WAHA_API_KEY_PLAIN")
-        if not self.api_key_hash:
+
+        # Gera automaticamente uma nova chave caso qualquer valor esteja ausente
+        if not self.api_key_hash or not self.api_key_plain:
             self.api_key_plain, self.api_key_hash = self._gerar_api_key()
             set_key(str(Path(".env")), "WAHA_API_KEY", self.api_key_hash)
-            os.environ["WAHA_API_KEY"] = self.api_key_hash
-            print_info(
-                f"API Key gerada. Guarde em local seguro: {self.api_key_plain}"
-            )
-        elif not self.api_key_plain:
-            self.api_key_plain = input(
-                "Digite a WAHA API Key em texto plano: "
-            ).strip()
-
-        # Garante que a chave em texto plano esteja disponível nas variáveis de ambiente
-        # e registrada no arquivo .env
-        if self.api_key_plain:
-            os.environ["WAHA_API_KEY_PLAIN"] = self.api_key_plain
             set_key(str(Path(".env")), "WAHA_API_KEY_PLAIN", self.api_key_plain)
+            print_info(
+                f"API Key gerada automaticamente. Guarde em local seguro: {self.api_key_plain}"
+            )
+
+        # Garante que ambas as versões estejam disponíveis nas variáveis de ambiente
+        os.environ["WAHA_API_KEY"] = self.api_key_hash
+        os.environ["WAHA_API_KEY_PLAIN"] = self.api_key_plain
 
         # Comando Docker corrigido
         self.comando_base = [


### PR DESCRIPTION
## Summary
- Generate and persist WAHA API key automatically when missing
- Remove manual key prompts and ensure key available to all processes
- Auto-configure webhook setup script to reuse or create API key

## Testing
- `python gerenciador_sistema.py --testar` *(fails: Conexão Ollama)*

------
https://chatgpt.com/codex/tasks/task_e_6895fe52a708832c9dccc9ad0932d5e3